### PR TITLE
Make full app area a link

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -3,10 +3,16 @@ import Icon from "./icon";
 import styled from "styled-components";
 import selectedTheme from "../lib/theme";
 
-const AppContainer = styled.div`
+const AppContainer = styled.a`
   display: flex;
-  flex: auto 25%;
+  flex: 1 0 auto;
   padding: 1rem;
+  color: ${selectedTheme.mainColor};
+  font-weight: 500;
+  text-transform: uppercase;
+  margin: 0;
+  text-decoration: none;
+  font-size: 1rem;
 `;
 
 const IconContainer = styled.div`
@@ -21,16 +27,8 @@ const DetailsContainer = styled.div`
   flex-direction: column;
 `;
 
-const AppLink = styled.a`
-  flex: 1 0 auto;
-  color: ${selectedTheme.mainColor};
-  font-weight: 500;
-  text-transform: uppercase;
-  margin: 0;
-  text-decoration: none;
-  font-size: 1rem;
-
-  &:hover {
+const AppName = styled.div`
+  a:hover & {
     text-decoration: underline;
   }
 `;
@@ -59,18 +57,18 @@ export const App = ({ name, icon, url, displayURL, newTab }: IAppProps) => {
 
   useEffect(() => { console.log(newTab) }, [newTab])
 
+  const linkAttrs = (newTab !== undefined && newTab) ? {
+    target: '_blank',
+    rel: 'noopener noreferrer',
+  } : {};
+
   return (
-    <AppContainer>
+    <AppContainer href={url} {...linkAttrs}>
       <IconContainer>
         <Icon name={icon} />
       </IconContainer>
       <DetailsContainer>
-
-        {
-          (newTab !== undefined && newTab) ?
-            <AppLink href={url} target="_blank" rel="noopener noreferrer">{name}</AppLink> : <AppLink href={url}>{name}</AppLink>
-        }
-
+        <AppName>{name}</AppName>
         <AppDescription>{displayURL}</AppDescription>
       </DetailsContainer>
     </AppContainer>


### PR DESCRIPTION
@phntxx Very cool app! I'm very interested in using it, but I also immediately found myself looking for the whole link "area" to be clickable as mentioned in the third point in #19. This PR does that. It effectively makes `AppContainer` the link element instead of having `AppLink` within `AppContainer`.

I also cleaned up the `return` to use a single element and moved the link attributes to its own object. Then those attributes get spread into the link element.