### PR TITLE
Add ability to set search placeholder text

### DIFF
--- a/data/search.json
+++ b/data/search.json
@@ -1,5 +1,6 @@
 {
   "search": {
+    "placeholder": "",
     "defaultProvider": "https://google.com/search?q=",
     "providers": [
       {

--- a/src/components/searchBar.tsx
+++ b/src/components/searchBar.tsx
@@ -44,6 +44,7 @@ export interface ISearchProviderProps {
 }
 
 export interface ISearchProps {
+  placeholder: string;
   defaultProvider: string;
   providers: Array<ISearchProviderProps> | undefined;
 }
@@ -104,6 +105,7 @@ const SearchBar = ({ search }: ISearchBarProps) => {
         type="text"
         data-testid="search-input"
         value={input}
+        placeholder={search.placeholder}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
           setInput(e.target.value)
         }

--- a/src/data/search.json
+++ b/src/data/search.json
@@ -1,5 +1,6 @@
 {
   "search": {
+    "placeholder": "",
     "defaultProvider": "https://google.com/search?q=",
     "providers": [
       {

--- a/src/lib/fetcher.tsx
+++ b/src/lib/fetcher.tsx
@@ -68,6 +68,7 @@ export const defaults = {
   },
   search: {
     search: {
+      placeholder: '',
       defaultProvider: "https://google.com/search?q=",
       providers: [],
     },


### PR DESCRIPTION
Defaults to an empty string, as the app currently works, but allows a user to set the `search.placeholder` property in `search.json`.