### PR TITLE
settings modal position fix

### DIFF
--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -17,6 +17,7 @@ const StyledButton = styled.button`
   border: none;
   padding: 0;
   background: none;
+  font-size: 1rem;
 
   &:hover {
     cursor: pointer;

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -7,9 +7,9 @@ import { IconButton } from "./icon";
 const ModalContainer = styled.div`
   position: absolute;
   left: 50%;
-  top: 50%;
+  top: 1rem;
   padding: 1rem;
-  transform: translate(-50%, -50%);
+  transform: translate(-50%, 0%);
   z-index: 10;
   border: 1px solid ${(props) => props.theme.mainColor};
   background-color: ${(props) => props.theme.backgroundColor};


### PR DESCRIPTION
Placing settings modal at top of screen instead of centered vertically, because the modal gets too long for the screen and ends up being cut off at the top.

Fix for #43 