### PR TITLE
Add `yarn format` script (`yarn prettier` was not writing formatted version)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "repository": "git@github.com:phntxx/dashboard",
-  "contributors": [
-    "phntxx <hello@phntxx.com>"
-  ],
+  "contributors": ["phntxx <hello@phntxx.com>"],
   "private": false,
   "dependencies": {
     "@types/node": "^14.14.37",
@@ -48,11 +46,7 @@
     "extends": "react-app"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
+    "production": [">0.2%", "not dead", "not op_mini all"],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --config .eslintrc.js",
     "prettier": "prettier --config .prettierrc.js '{data,src}/**/*.{json,ts,tsx}'",
-    "format": "yarn prettier -w",
+    "format": "prettier -w --config .prettierrc.js '{data,src}/**/*.{json,ts,tsx}'",
     "http-server:data": "http-server ./ -c-1",
     "http-server:app": "http-server ./build --proxy http://localhost:8080 --port 3000",
     "serve:production": "npm-run-all --parallel http-server:data http-server:app"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eject": "react-scripts eject",
     "lint": "eslint --config .eslintrc.js",
     "prettier": "prettier --config .prettierrc.js '{data,src}/**/*.{json,ts,tsx}'",
+    "format": "yarn prettier -w",
     "http-server:data": "http-server ./ -c-1",
     "http-server:app": "http-server ./build --proxy http://localhost:8080 --port 3000",
     "serve:production": "npm-run-all --parallel http-server:data http-server:app"


### PR DESCRIPTION
Currently `yarn prettier` script does not actually format files, just shows what they would look like when formatted.

This PR:
- Adds a `yarn format` script that uses the `-w` flag to overwrite the files with their formatted version.
- Formats all files using the `yarn format` command (which updated the `package.json` formatting slightly)